### PR TITLE
Changes for optional update of PR comment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Below are the inputs for the action.
   - Optional
   - Default: 'false'
 
+* `update-pr-comment`
+
+  Pass true/false to update the PR comment with terraform plan output. 
+
+  - Type: string
+  - Optional
+  - Default: 'false'
+
 ## Outputs
 
 * `tf-fmt-outcome`
@@ -96,9 +104,7 @@ Below are the inputs for the action.
 
 ## Example usage
 
-### WIP
-
-This example workflow runs when PR is created or made ready for review to main.
+This example workflow runs when PR is created or made ready for review to main. It will show the output of the terraform plan in the PR comment. To apply the terrafom plan directly without review of the plan output, pass 'true' to 'apply-terraform'.
 
 ```yaml
 name: Apply
@@ -153,6 +159,10 @@ jobs:
           pr-dir: $DIR_PATH
           # SSH private key to add to the list of keys for downloading terraform modules from the remote GitHub repository
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          # Pass true/false to apply the terraform changes
+          apply-terraform: false
+          # Pass true/false to update the PR comment with terraform plan output
+          update-pr-comment: true
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,11 @@ inputs:
     required: false
     description: 'Pass true/false to apply the terraform changes'
     default: 'false'
+  update-pr-comment:
+    required: false
+    description: 'Pass true/false to update the PR comment with terraform plan output'
+    default: 'false'
+    
 outputs:
   tf-fmt-outcome:
     description: Outcome of the 'terraform fmt' command
@@ -179,11 +184,13 @@ runs:
         cd ${PWD}/${{ inputs.tf-working-dir }}
         pwd
         terraform plan -lock=false -no-color ${{ steps.get-targets.outputs.targets }}
+      continue-on-error: true
 
     # Write back to the PR the output of the terraform plan
     - name: get PR comment
       uses: actions/github-script@v6
       id: prepare-comment
+      if: ${{ inputs.update-pr-comment}} = true 
       env:
         PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
       with:
@@ -229,6 +236,11 @@ runs:
               body: output
             })
           }
+    - name: Terraform Plan Status
+      id: check-plan-status
+      shell: bash
+      if: steps.plan.outcome == 'failure'
+      run: exit 1
 
     # Terraform apply
     - name: Terraform apply


### PR DESCRIPTION
Now user can pass an argument to optionally update the PR comment with terraform commands' output. Later the output can be uploaded as an artifact to the workflow.